### PR TITLE
Fix JSON extraction when formatting data

### DIFF
--- a/utils/json2data.py
+++ b/utils/json2data.py
@@ -2,17 +2,30 @@ import json
 import re
 
 
-def format_json_to_data(json_str):
+def format_json_to_data(json_str: str) -> str:
+    """Convert a JSON string to the <data> format used by the pipeline.
+
+    The model responses are not always guaranteed to be valid JSON. This
+    function extracts the JSON portion and converts it to the expected
+    ``<data>`` block. If no JSON can be found or parsed, the original string is
+    returned unchanged so the caller can decide how to handle it.
+    """
+
     pattern = r"\{.*\}"
     match = re.search(pattern, json_str, re.DOTALL)
+    if not match:
+        # Return original text when no JSON structure is detected
+        return json_str
 
-    json_str = match.group(0)
+    json_part = match.group(0)
+    try:
+        data = json.loads(json_part)
+    except json.JSONDecodeError:
+        # If parsing fails, fall back to the raw JSON string
+        return json_str
 
-
-    data = json.loads(json_str)
     output = "<data>\n"
-    for key in data.keys():
-        items = data[key]
+    for key, items in data.items():
         if not isinstance(items, list):
             items = [str(items)]
         output += f"{key}: {', '.join(items)}\n"


### PR DESCRIPTION
## Summary
- handle invalid or missing JSON in `format_json_to_data`

## Testing
- `python - <<'EOF'
import glob, py_compile
for f in glob.glob('**/*.py', recursive=True):
    py_compile.compile(f)
print('All compiled successfully')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6841aa76f904832b88aeffe2dee13bfb