### PR TITLE
Fix JSON conversion with numeric list items

### DIFF
--- a/pipeline/data_preparation.py
+++ b/pipeline/data_preparation.py
@@ -24,9 +24,10 @@ def get_data(task, model):
         json_str = match.group(0)
         data = json.loads(json_str)
         output = "<data>\n"
-        for key in data.keys():
-            items = data[key]
-            if not isinstance(items, list):
+        for key, items in data.items():
+            if isinstance(items, list):
+                items = [str(item) for item in items]
+            else:
                 items = [str(items)]
             output += f"{key}: {', '.join(items)}\n"
         # output += f"Task: {task}\n"


### PR DESCRIPTION
## Summary
- ensure list items are stringified in `format_json_to_data`
- apply same fix in data preparation

## Testing
- `python - <<'EOF'
import glob, py_compile
for f in glob.glob('**/*.py', recursive=True):
    py_compile.compile(f)
print('All compiled successfully')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6841aa76f904832b88aeffe2dee13bfb